### PR TITLE
Typo for `vaderSentiment`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ rdflib==6.0.0
 scikit-learn==0.24.2
 spacy==3.1.1
 textblob==0.15.3
-vaderSentiment=3.3.2
+vaderSentiment==3.3.2
 wheel==0.37.0


### PR DESCRIPTION
Error from `dependabot`

> InstallationError("Invalid requirement: 'vaderSentiment=3.3.2' (from line 12 of /home/dependabot/dependabot-updater/dependabot_tmp_dir/requirements.txt)\nHint: = is not a valid operator. Did you mean == ?")